### PR TITLE
Changed raw new/deletes to unique_ptr for exception safety

### DIFF
--- a/src/HapticLibrary.cpp
+++ b/src/HapticLibrary.cpp
@@ -40,11 +40,11 @@ const char* GetExePath() {
         std::wstring path = szBuffer;
         int size = WideCharToMultiByte(CP_UTF8, 0, path.c_str(), -1, NULL, 0, NULL, NULL);
 
-        char *buffer = new char[size + 1];
-        WideCharToMultiByte(CP_UTF8, 0, path.c_str(), -1, buffer, size, NULL, NULL);
-        std::string str(buffer);
+        std::unique_ptr<char[]> buffer(new char[size + 1]);
 
-        delete[]buffer;
+        WideCharToMultiByte(CP_UTF8, 0, path.c_str(), -1, buffer.get(), size, NULL, NULL);
+        std::string str(buffer.get());
+
         exeFilePath = str;
     }
 #else
@@ -77,11 +77,11 @@ bool TryGetExePath(char* buf, int& buf_size)
         std::wstring path = szBuffer;
         int size = WideCharToMultiByte(CP_UTF8, 0, path.c_str(), -1, NULL, 0, NULL, NULL);
 
-        char *buffer = new char[size + 1];
-        WideCharToMultiByte(CP_UTF8, 0, path.c_str(), -1, buffer, size, NULL, NULL);
-        std::string str(buffer);
+        std::unique_ptr<char[]> buffer(new char[size + 1]);
 
-        delete[]buffer;
+        WideCharToMultiByte(CP_UTF8, 0, path.c_str(), -1, buffer.get(), size, NULL, NULL);
+        std::string str(buffer.get());
+
         exeFilePath = str;
         buf_size = (int)exeFilePath.size();
         std::cout << buf_size << std::endl;


### PR DESCRIPTION
This PR changes the raw `new`/`delete` calls in HapticLibrary to use std::unique_ptr to improve exception safety.

Reason for change:
```cpp
char *buffer = new char[size + 1];

WideCharToMultiByte(CP_UTF8, 0, path.c_str(), -1, buffer, size, NULL, NULL); //memory leak if this throws 
std::string str(buffer); //memory leak if this throws

delete[]buffer;
```
Currently code in the HapticLibrary uses raw new and delete for these functions. This is an issue because if anything between the new and delete throws an exception, the control is transferred out of this function and the `delete` call will never be made.

This PR fixes this by changing the raw pointer to a `std::unique_ptr`, which automatically frees the memory if it goes out of scope, guaranteeing that even if an exception is thrown the memory will be freed.

I realize that its unlikely that the std::string constructor and the other code there will throw, but its good practice and helps if more code is added later.

This PR resolves issue #201.